### PR TITLE
resolving namespace prefix from source xml

### DIFF
--- a/Sources/XMLTools/Infoset.swift
+++ b/Sources/XMLTools/Infoset.swift
@@ -14,7 +14,7 @@ extension XMLTools.QName: InfosetSelector {}
 public class Infoset: Sequence {
     public typealias XMLElement = XMLTools.Element
 
-    open static let EMPTY = Infoset()
+    public static let EMPTY = Infoset()
 
     open var selectedNodes: [Node]
     open var parentDocument: Document
@@ -96,6 +96,9 @@ public class Infoset: Sequence {
         if name.range(of: ":") != nil {
             let tuple = name.components(separatedBy: ":")
             if let uri = contextElement()?.resolveURI(forPrefix: tuple[0]) {
+                return QName(tuple[1], uri: uri)
+            }
+            if let uri = contextElement()?.resolveURIFromSource(forPrefix: tuple[0]) {
                 return QName(tuple[1], uri: uri)
             }
             return QName(tuple[1])

--- a/Tests/XMLToolsTests/NamespaceTests.swift
+++ b/Tests/XMLToolsTests/NamespaceTests.swift
@@ -66,6 +66,9 @@ class NamespaceTests: XCTestCase {
         XCTAssertEqual("Test1_1_1Test1_1_2", xml["level1", "level1_1"].text)
         XCTAssertEqual("Test1_2_1Test1_2_2", xml["level1", "level1_2"].text)
         
+        XCTAssertEqual("Test1_1_1", xml["level1", "level1_1", QName("level1_1_1", uri: "urn:dummy_A")].text)
+        XCTAssertEqual("Test1_1_1", xml["level1", "level1_1", "nsA:level1_1_1"].text)
+        
         xml.namespaceContext.declare("custom_A", uri: "urn:dummy_A")
         xml.namespaceContext.declare("custom_A_2", uri: "urn:dummy_A")
         XCTAssertEqual("Test1_1_1", xml["level1", "level1_1", "custom_A:level1_1_1"].text)


### PR DESCRIPTION
Resolving an element in DOM which bases on XML file with namespaces requires to add a namespace prefix to a namespace context, like described:

```
// equivalent to xmlns:wsdl="http://www.w3.org/ns/wsdl"
xml.namespaceContext.declare("w", uri: "http://www.w3.org/ns/wsdl")
print (xml["w:description", "w:documentation"].text)
```
This is fine and interoperabel because namespace prefixes can change even if the namepsace itself remains the same.
But if you want to be lazy you should think of using the namespace prefix from source xml without declaring an own one.

```
// <... xmlns:wsdl="http://www.w3.org/ns/wsdl">
print (xml["wsdl:description", "wsdl:documentation"].text)
```
This was simply added by calling the resolver for resolving namespace prefix from source xml if the resolver for resolving from context does not find any declared prefix. 