### PR TITLE
Removes Infoset.EMPTY singleton.

### DIFF
--- a/Sources/XMLTools/Infoset+Descendant.swift
+++ b/Sources/XMLTools/Infoset+Descendant.swift
@@ -10,7 +10,7 @@ extension Infoset {
         let selection = Infoset([Node](), from: document())
 
         if selectedNodes.count == 0 {
-            return Infoset.EMPTY
+            return Infoset()
         }
 
         for node in selectedNodes {
@@ -29,7 +29,7 @@ extension Infoset {
         let selection = Infoset([Node](), from: document())
 
         if selectedNodes.count == 0 {
-            return Infoset.EMPTY
+            return Infoset()
         }
 
         for node in selectedNodes where node as? XMLElement != nil {

--- a/Sources/XMLTools/Infoset+Manipulation.swift
+++ b/Sources/XMLTools/Infoset+Manipulation.swift
@@ -31,7 +31,7 @@ extension Infoset {
                 return Infoset(newElement)
             }
         }
-        return .EMPTY
+        return Infoset()
     }
 
     /**

--- a/Sources/XMLTools/Infoset+Parent.swift
+++ b/Sources/XMLTools/Infoset+Parent.swift
@@ -14,6 +14,6 @@ extension Infoset {
                 return Infoset(parentNode)
             }
         }
-        return Infoset.EMPTY
+        return Infoset()
     }
 }

--- a/Sources/XMLTools/Infoset.swift
+++ b/Sources/XMLTools/Infoset.swift
@@ -14,12 +14,13 @@ extension XMLTools.QName: InfosetSelector {}
 public class Infoset: Sequence {
     public typealias XMLElement = XMLTools.Element
 
-    public static let EMPTY = Infoset()
-
     open var selectedNodes: [Node]
     open var parentDocument: Document
 
-    private init() {
+    /**
+     * Create an empty Infoset()
+     */
+    public init() {
         selectedNodes = [Node]()
         parentDocument = Document()
     }
@@ -190,7 +191,7 @@ public class Infoset: Sequence {
         if index < selectedNodes.count {
             return Infoset(selectedNodes[index])
         }
-        return Infoset.EMPTY
+        return Infoset()
     }
 
     public func select(_ name: String) -> Infoset {
@@ -218,7 +219,7 @@ public class Infoset: Sequence {
         case let qname as XMLTools.QName:
             return select(qname)
         default:
-            return Infoset.EMPTY
+            return Infoset()
         }
     }
 
@@ -285,7 +286,7 @@ public class Infoset: Sequence {
         if let lastNode = selectedNodes.last {
             return Infoset(lastNode)
         }
-        return Infoset.EMPTY
+        return Infoset()
     }
 
     public func merge(with otherSelection: Infoset) {


### PR DESCRIPTION
`Infoset.EMPTY` was dangerous because `EMPTY` returned a reference to a single
Infoset instance. Infoset is a mutable reference type, so `EMPTY` could
easily be mutated by client (or internal) code by accident, e.g. via `Infoset.merge(with:)`, making `EMPTY` no longer empty and causing un-expected side-effects.

Note: I considered implementing `Infoset.EMPTY` as a computed property,
returning a new `Infoset()`, to avoid changing the public API. However, I think the semantics are clearer at the call site if Infoset init() is public. This also results in more idiomatic Swift code (again at the call site).